### PR TITLE
Add SECURITY.md and Renovate configuration

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release line receives security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 2.x     | :white_check_mark: |
+| < 2.0   | :x:                |
+
+## Reporting a Vulnerability
+
+Please **do not** report security vulnerabilities through public GitHub issues.
+
+Instead, use GitHub's [private vulnerability reporting](https://github.com/konradmichalik/weather-iconic/security/advisories/new)
+to disclose the issue privately. This lets us investigate and release a fix
+before the details become public.
+
+Please include as much of the following as you can:
+
+- A description of the vulnerability and its impact
+- Steps to reproduce or a proof of concept
+- Affected version(s)
+- Any suggested mitigation or fix
+
+We aim to acknowledge reports within a few business days and will keep you
+informed about the progress toward a fix.
+
+## Scope
+
+`weather-iconic` ships as a static icon set with **no runtime dependencies**,
+so the published package has a very small attack surface. Security reports are
+most relevant for the build tooling (`devDependencies`) and the generated
+distribution artifacts.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    "group:allNonMajor"
+  ],
+  "labels": ["dependencies"],
+  "prConcurrentLimit": 5,
+  "packageRules": [
+    {
+      "description": "Automerge non-major devDependency updates once CI passes",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
+      "description": "Keep GitHub Actions up to date",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the two missing repository health/automation files identified in the audit:

- **`SECURITY.md`** — a security policy that routes reports through GitHub's private vulnerability reporting and documents that the published package has no runtime dependencies (attack surface is limited to build tooling).
- **`renovate.json`** — Renovate config (`config:recommended` + dependency dashboard, semantic commits, non-major grouping). Non-major devDependency updates automerge once CI passes; GitHub Actions are grouped. This addresses the root cause of the current dev-dependency vulnerability backlog.

## Notes

- Renovate config assumes the Renovate GitHub App (or Mend) is installed on the account. If Dependabot is preferred instead, this can be swapped for a `.github/dependabot.yml`.
- The major devDependency bumps flagged in the audit (puppeteer, vite, vitest, …) are handled in a separate PR; Renovate will keep things current from here on.

Part of the 2026-07-24 repository audit follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EM75A9e2ZtLB1GchMUB1uM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a security policy outlining supported release versions, vulnerability reporting procedures, response expectations, and policy scope.

* **Chores**
  * Added automated dependency update configuration, including grouped GitHub Actions updates and automatic merging of eligible non-major development dependency updates after successful checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->