### PR TITLE
Fix stale jackd248 handle in metadata and README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A minimal multi-color weather icon set containing 100 icons offered in multiple 
 - PNG exports in multiple sizes (16px to 128px) with retina support
 
 > [!NOTE]
-> Originally made for the weather app [temps](https://jackd248.github.io/temps/).
+> Originally made for the weather app [temps](https://konradmichalik.github.io/temps/).
 
 - [Features](#features)
 - [Icons](#icons)
@@ -43,7 +43,7 @@ A minimal multi-color weather icon set containing 100 icons offered in multiple 
 All 100 weather icons with exemplary multi-color visual previews:
 
 > [!TIP]
-> Search for specific icons within the landing page: https://jackd248.github.io/weather-iconic/
+> Search for specific icons within the landing page: https://konradmichalik.github.io/weather-iconic/
 
 > [!NOTE]
 > Icons are also available in single-color versions in the same packages.

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "license": "CC-BY-SA-3.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jackd248/weather-iconic.git"
+    "url": "https://github.com/konradmichalik/weather-iconic.git"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",


### PR DESCRIPTION
## Summary

Updates references to the old GitHub handle (`jackd248`) to the current one (`konradmichalik`):

- `package.json` → `repository.url`: `jackd248/weather-iconic` → `konradmichalik/weather-iconic`
- `README.md`: two `jackd248.github.io` landing-page links → `konradmichalik.github.io`

No `jackd248` references remain in `README.md` or `package.json` after this change.

Part of the 2026-07-24 repository audit follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EM75A9e2ZtLB1GchMUB1uM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the referenced weather app link.
  * Revised the icon-search landing page link in the README.
  * Updated the project repository URL in package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->