### PR TITLE
Harden release and publish workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,15 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Required for npm Trusted Publishing (OIDC) and provenance
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
+      # npm Trusted Publishing requires npm >= 11.5.1
+      - name: Update npm
+        run: npm install -g npm@latest
+      # Publishes via OIDC Trusted Publishing — no NPM_TOKEN needed.
+      # A trusted publisher must be configured for this package on npmjs.com.
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,8 @@ jobs:
       # Required for npm Trusted Publishing (OIDC) and provenance
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       release-notes-url: ${{ steps.create-release.outputs.url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
@@ -30,6 +30,6 @@ jobs:
       # Create release
       - name: Create release
         id: create-release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: write
+
 jobs:
   # Job: Create release
   release:
@@ -20,7 +23,7 @@ jobs:
       # Check if tag is valid
       - name: Check tag
         run: |
-          if ! [[ ${{ github.ref }} =~ ^refs/tags/[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$ ]]; then
+          if ! [[ ${{ github.ref }} =~ ^refs/tags/[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
             exit 1
           fi
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,18 +30,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Copy dist and src to landing directory
         run: |
           cp -r ./dist ./landing/
           cp -r ./src ./landing/
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           # Upload entire repository
           path: './landing'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## Summary

CI/workflow hardening from the audit:

- **`publish.yml` → npm Trusted Publishing (OIDC).** Removes the `NPM_TOKEN` secret entirely and relies on the already-present `id-token: write` permission. npm is updated to a version that supports OIDC (`>= 11.5.1`) before publishing. Provenance is retained.
- **`release.yml` → least-privilege permissions.** Adds an explicit top-level `permissions: contents: write` block (previously unset, so the job inherited broad defaults).
- **`release.yml` → tag regex fix.** Escapes the dots (`\.`) in the version regex so it no longer also matches strings like `1x2x3`.
- **All workflows → actions pinned to commit SHAs.** Every action (`actions/checkout`, `actions/setup-node`, `softprops/action-gh-release`, `actions/configure-pages`, `actions/upload-pages-artifact`, `actions/deploy-pages`) is pinned to a full commit SHA with a `# vX.Y.Z` comment instead of a mutable tag. Renovate (see the Renovate PR) keeps these digests updated.

## ⚠️ Required before the next release

Trusted Publishing needs a one-time **manual setup on npmjs.com**: configure a trusted publisher for `weather-iconic` pointing at this repo and the `Publish` workflow (`.github/workflows/publish.yml`). Until that is done, `npm publish` in this workflow will fail. Once configured, the `NPM_TOKEN` repository secret can be deleted.

Docs: <https://docs.npmjs.com/trusted-publishers>

Part of the 2026-07-24 repository audit follow-up.