### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,62 @@
+name: 🐞 Bug report
+description: Report a problem with an icon, the webfont, sprite, or the package.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report! Please fill out the
+        sections below so we can reproduce and fix the issue.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce the problem?
+      placeholder: |
+        1. Import '...'
+        2. Render icon '...'
+        3. See '...'
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: dropdown
+    id: integration
+    attributes:
+      label: Integration
+      description: Which integration option is affected?
+      options:
+        - SVG sprite
+        - Webfont (WOFF2/WOFF/TTF)
+        - PNG
+        - JS/TS constants
+        - Other / not sure
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: weather-iconic version
+      placeholder: e.g. 2.2.0
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser / bundler / framework, if relevant.
+      placeholder: e.g. Chrome 126, Vite 7, React 18
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/konradmichalik/weather-iconic/security/advisories/new
+    about: Please report security issues privately, not as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: 💡 Feature or icon request
+description: Suggest a new icon, integration option, or other improvement.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your idea! Use this for new icon suggestions as well as
+        general feature requests.
+  - type: dropdown
+    id: type
+    attributes:
+      label: Request type
+      options:
+        - New icon(s)
+        - New / improved integration option
+        - Other improvement
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like to see?
+      description: |
+        Describe the icon(s) or feature. For new icons, please describe the
+        weather concept and, if possible, link a reference.
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation / use case
+      description: What problem does this solve, or where would you use it?
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

Adds the missing issue templates (the last of the community health files flagged in the audit; `SECURITY.md` and `CONTRIBUTING.md` are handled in their own PRs).

- **`bug_report.yml`** — structured bug report form (description, repro, expected behavior, affected integration, version, environment).
- **`feature_request.yml`** — feature / new-icon request form.
- **`config.yml`** — disables blank issues and adds a contact link routing security reports to GitHub private vulnerability reporting (consistent with `SECURITY.md`).

## Notes

- Kept scoped to the audit's "issue templates" finding. A `pull_request_template.md` isn't included — happy to add one if you'd like.

Part of the 2026-07-24 repository audit follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EM75A9e2ZtLB1GchMUB1uM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added structured forms for submitting bug reports and feature or icon requests.
  * Bug reports now collect reproduction steps, expected behavior, integration details, version, and environment information.
  * Feature requests include request type, proposal, and optional motivation.
  * Disabled blank issue submissions and added guidance for privately reporting security vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->